### PR TITLE
Updating setup.py to include .smk files in installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ setup(
     include_package_data=True,
     package_data={'nanomotif': [
         'datasets/*',
-        '*.smk',
+        'mtase_linker/*.smk',
         '*.yaml',
         "mtase_linker/envs/*",
         "mtase_linker/src/*"


### PR DESCRIPTION
Including .smk files in installation. Specified that the files should be included from the "mtase_linker" directory.