### PR TITLE
#Mtase_linker motif_assignment.py needed updating for 0.6.2

### DIFF
--- a/nanomotif/mtase_linker/src/motif_assignment.py
+++ b/nanomotif/mtase_linker/src/motif_assignment.py
@@ -36,7 +36,7 @@ nanomotif_table = pd.read_csv(nanomotif_table_path, sep = "\t", header = 0)
 nanomotif_table['assign_mod_type'] = nanomotif_table['mod_type'].apply(recode_mod_type)
 
 #Set motif acceptance threshold as >=0.5 mean_methylation and remove ambiguous motifs in nanomotif_table
-mean_methylation = nanomotif_table['n_mod_bin'] / (nanomotif_table['n_mod_bin'] + nanomotif_table['n_nomod_bin'])
+mean_methylation = nanomotif_table['n_mod'] / (nanomotif_table['n_mod'] + nanomotif_table['n_nomod'])
 nanomotif_table_mm50 = nanomotif_table[mean_methylation >= snakemake.params['MINIMUM_METHYLATION']]
 
 
@@ -268,7 +268,7 @@ MTase_table_assigned = MTase_table_assigned[['bin name', 'gene_id', 'contig', 'm
 MTase_table_assigned.columns = ['bin', 'gene_id', 'contig', 'mod_type_pred', 'sub_type_pred', 'RM_system', 'DF_system_ID', 'motif_type_pred', 'REbase_ID', 'motif_pred', 'linked', 'detected_motif']
 MTase_table_assigned_cl = MTase_table_assigned.dropna(subset=['bin'])
 
-nanomotif_table_mm50 = nanomotif_table_mm50[['bin', 'mod_type', 'motif', 'mod_position', 'n_mod_bin', 'n_nomod_bin', 'motif_type', 'motif_complement', 'mod_position_complement', 'n_mod_complement', 'n_nomod_complement', 'linked', 'candidate_genes']]
+nanomotif_table_mm50 = nanomotif_table_mm50[['bin', 'mod_type', 'motif', 'mod_position', 'n_mod', 'n_nomod', 'motif_type', 'motif_complement', 'mod_position_complement', 'n_mod_complement', 'n_nomod_complement', 'linked', 'candidate_genes']]
 #%%
 MTase_table_assigned_cl.to_csv(snakemake.output['MTase_assignment_table'] , sep='\t', index=False)
 nanomotif_table_mm50.to_csv(snakemake.output['nanomotif_assignment_table'] , sep='\t', index=False)


### PR DESCRIPTION
I ran into the following issue with MTase-linker in v0.6.2:
```
Traceback (most recent call last):
  File "/scratch/brbloemen/AMR_transfer/COAP/Ecoli/Autocycler/NanoMotif/.snakemake/scripts/tmp1sykkmlb.motif_assignment.py", line 42, in <module>
    mean_methylation = nanomotif_table['n_mod_bin'] / (nanomotif_table['n_mod_bin'] + nanomotif_table['n_nomod_bin'])
                       ~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/data/brbloemen/db/NanoMotif/ML_dependencies/ML_envs/78df45f45de7d7e56b92217e7487e80e_/lib/python3.12/site-packages/pandas/core/frame.py", line 3893, in __getitem__
    indexer = self.columns.get_loc(key)
              ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/data/brbloemen/db/NanoMotif/ML_dependencies/ML_envs/78df45f45de7d7e56b92217e7487e80e_/lib/python3.12/site-packages/pandas/core/indexes/base.py", line 3797, in get_loc
    raise KeyError(key) from err
KeyError: 'n_mod_bin'
```


Issue was caused by the bin-motifs.tsv having an n_mod column instead of n_mod_bin (same for no_mod_bin):
```
bin	motif	mod_position	mod_type	n_mod	n_nomod	motif_type	motif_complement	mod_position_complement	n_mod_complement	n_nomod_complement
bin1	GAGACC	3	a	348	65	non-palindrome				
bin1	GATC	1	a	40533	857	palindrome	GATC	1	40533	857
bin1	RTACNNNNGTG	2	a	696	14	bipartite	CACNNNNGTAY	1	688	22
bin1	CCCGGA	2	m	1628	1325	non-palindrome				
bin1	CCWGG	1	m	26501	208	palindrome	CCWGG	1	26501	208
bin1	CTCCGGAKRA	3	m	27	10	non-palindrome				
bin1	GGTCTC	3	m	411	4	non-palindrome				
bin1	YCCGGG	2	m	2700	1513	non-palindrome		
```